### PR TITLE
Attempted to fix a null-pointer exception in LOBsTracker.java

### DIFF
--- a/dbptk-core/src/main/java/com/databasepreservation/modules/siard/out/content/LOBsTracker.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/modules/siard/out/content/LOBsTracker.java
@@ -105,12 +105,16 @@ public class LOBsTracker {
     Map<Integer, Integer> maxClobLengthInColumn = maxCLOBlength.get(table);
     if (maxClobLengthInColumn == null) {
       maxClobLengthInColumn = new HashMap<Integer, Integer>();
-      maxClobLengthInColumn.put(column, length);
       maxCLOBlength.put(table, maxClobLengthInColumn);
     }
 
-    if (maxClobLengthInColumn.get(column) < length) {
-      maxClobLengthInColumn.put(column, length);
+    if (!maxClobLengthInColumn.containsKey(column)) {
+		maxClobLengthInColumn.put(column, length);
+    }
+    else {
+	    if (maxClobLengthInColumn.get(column) < length) {
+	      maxClobLengthInColumn.put(column, length);
+	    }
     }
   }
 


### PR DESCRIPTION
I encountered a null-pointer exception in LOBsTracker.java, when trying to export a sample database from PostgreSQL to siard-dk. Looking at the code, I can see how this could happen. I have therefore attempted to create a fix.
