### PR TITLE
Import module fix win paths + misc small cross platform issues.

### DIFF
--- a/dbptk-core/src/main/java/com/databasepreservation/modules/siard/in/read/FolderReadStrategyMD5Sum.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/modules/siard/in/read/FolderReadStrategyMD5Sum.java
@@ -20,11 +20,13 @@ public class FolderReadStrategyMD5Sum extends FolderReadStrategy {
 
   protected Map<DigestInputStream, byte[]> expectedMD5SumForStream;
   protected Map<DigestInputStream, String> pathAssociatedWithStream;
+  protected Map<DigestInputStream, SIARDArchiveContainer> archiveAssociatedWithStream;
 
   public FolderReadStrategyMD5Sum(SIARDArchiveContainer mainContainer) {
     super(mainContainer);
     expectedMD5SumForStream = new HashMap<DigestInputStream, byte[]>();
     pathAssociatedWithStream = new HashMap<DigestInputStream, String>();
+    archiveAssociatedWithStream = new HashMap<DigestInputStream, SIARDArchiveContainer>();
   }
 
   public DigestInputStream createInputStream(SIARDArchiveContainer container, String path, byte[] expectedMD5Sum)
@@ -34,6 +36,7 @@ public class FolderReadStrategyMD5Sum extends FolderReadStrategy {
         MessageDigest.getInstance("MD5"));
       expectedMD5SumForStream.put(digestInputStream, expectedMD5Sum);
       pathAssociatedWithStream.put(digestInputStream, path);
+      archiveAssociatedWithStream.put(digestInputStream, container);
       return digestInputStream;
     } catch (NoSuchAlgorithmException e) {
       throw new ModuleException(e);
@@ -46,11 +49,12 @@ public class FolderReadStrategyMD5Sum extends FolderReadStrategy {
         byte[] expectedMD5Sum = expectedMD5SumForStream.remove(inputStream);
         byte[] computedMD5Sum = inputStream.getMessageDigest().digest();
         String path = pathAssociatedWithStream.remove(inputStream);
+        SIARDArchiveContainer container = archiveAssociatedWithStream.remove(inputStream);
         if (!MessageDigest.isEqual(computedMD5Sum, expectedMD5Sum)) {
           String expectedMD5SumStr = Hex.encodeHexString(expectedMD5Sum);
           String computedMD5SumStr = Hex.encodeHexString(computedMD5Sum);
           throw new ModuleException("Error verifying MD5sum for file [" + path + "]. Computed: " + computedMD5SumStr
-            + " Expected:" + expectedMD5SumStr + " ");
+            + " Expected:" + expectedMD5SumStr + " - during processing of archive [" + container.getPath() + "]");
         }
       } else {
         throw new IllegalArgumentException(

--- a/dbptk-core/src/main/java/com/databasepreservation/modules/siard/out/metadata/FileIndexFileStrategy.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/modules/siard/out/metadata/FileIndexFileStrategy.java
@@ -17,12 +17,14 @@ import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import com.databasepreservation.model.exception.ModuleException;
 import com.databasepreservation.model.structure.DatabaseStructure;
 import com.databasepreservation.modules.siard.common.SIARDArchiveContainer;
 import com.databasepreservation.modules.siard.constants.SIARDDKConstants;
 import com.databasepreservation.modules.siard.out.write.WriteStrategy;
+
 import dk.sa.xmlns.diark._1_0.fileindex.FileIndexType;
 
 /**
@@ -62,7 +64,7 @@ public class FileIndexFileStrategy implements IndexFileStrategy {
       // System.out.println(entry.getKey() + " " + entry.getValue());
 
       String path = entry.getKey();
-      String[] splitPath = path.split(SIARDDKConstants.FILE_SEPARATOR);
+      String[] splitPath = path.split(Pattern.quote(SIARDDKConstants.FILE_SEPARATOR));
       String fiN = splitPath[splitPath.length - 1];
       // System.out.println(fiN);
 

--- a/dbptk-core/src/main/java/com/databasepreservation/modules/siard/out/metadata/FileIndexFileStrategy.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/modules/siard/out/metadata/FileIndexFileStrategy.java
@@ -14,9 +14,10 @@ import java.nio.file.Path;
 import java.security.DigestOutputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
 import java.util.regex.Pattern;
 
 import com.databasepreservation.model.exception.ModuleException;
@@ -39,11 +40,11 @@ public class FileIndexFileStrategy implements IndexFileStrategy {
   private MessageDigest messageDigest;
   private MessageDigest lobMessageDigest;
   private boolean currentlyDigestingLOB;
-  private Map<String, byte[]> md5sums;
+  private SortedMap<String, byte[]> md5sums;
   private SIARDArchiveContainer outputContainer;
 
   public FileIndexFileStrategy() {
-    md5sums = new HashMap<String, byte[]>();
+    md5sums = new TreeMap<String, byte[]>();
     outputContainer = null;
     currentlyDigestingLOB = false;
   }

--- a/dbptk-core/src/main/java/com/databasepreservation/modules/siard/out/path/SIARDDKContentPathExportStrategy.java
+++ b/dbptk-core/src/main/java/com/databasepreservation/modules/siard/out/path/SIARDDKContentPathExportStrategy.java
@@ -83,9 +83,9 @@ public class SIARDDKContentPathExportStrategy implements ContentPathExportStrate
 
   @Override
   public String getTableXsdNamespace(String base, int schemaIndex, int tableIndex) {
-    return new StringBuilder().append(base).append(SCHEMA_DIR).append(schemaIndex)
-      .append(SIARDDKConstants.FILE_SEPARATOR).append(TABLE_FILENAME).append(tableIndex)
-      .append(SIARDDKConstants.FILE_EXTENSION_SEPARATOR).append(SIARDDKConstants.XSD_EXTENSION).toString();
+    return new StringBuilder().append(base).append(SCHEMA_DIR).append(schemaIndex).append("/").append(TABLE_FILENAME)
+      .append(tableIndex).append(SIARDDKConstants.FILE_EXTENSION_SEPARATOR).append(SIARDDKConstants.XSD_EXTENSION)
+      .toString();
   }
 
   @Override

--- a/dbptk-core/src/test/java/com/databasepreservation/siarddk/SIARDDKTestUtil.java
+++ b/dbptk-core/src/test/java/com/databasepreservation/siarddk/SIARDDKTestUtil.java
@@ -7,14 +7,12 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.regex.Pattern;
 
-import org.apache.commons.codec.Charsets;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
 import org.testng.FileAssert;
 
 import com.databasepreservation.CustomLogger;
 import com.databasepreservation.Main;
-import com.databasepreservation.modules.siard.constants.SIARDDKConstants;
 
 /*
  * @author Thomas Kristensen tk@bithuset.dk
@@ -73,34 +71,14 @@ public class SIARDDKTestUtil {
     byte[] expectedFileContent = FileUtils.readFileToByteArray(expectedFile);
     byte[] actualFileContent = FileUtils.readFileToByteArray(actualFile);
 
-    String expectedFileContentStr = new String(expectedFileContent, Charsets.UTF_8);
-    String actualFileStr = new String(actualFileContent, Charsets.UTF_8);
-
-    // neutralize file platform specific line endings in the comparison
-    expectedFileContentStr = expectedFileContentStr.replace("\n", System.lineSeparator());
-
-    String expectedSha1 = DigestUtils.sha1Hex(expectedFileContentStr);
-    String actualSha1 = DigestUtils.sha1Hex(actualFileStr);
+    String expectedSha1 = DigestUtils.sha1Hex(expectedFileContent);
+    String actualSha1 = DigestUtils.sha1Hex(actualFileContent);
 
     if (!expectedSha1.equals(actualSha1)) {
-
-      // Special case: Expected md5sums in fileIndex.xml will not match when
-      // line endings have been substituted.
-      if (actualFile.getName().equals(
-        SIARDDKConstants.FILE_INDEX + SIARDDKConstants.FILE_EXTENSION_SEPARATOR + SIARDDKConstants.XML_EXTENSION)
-        && expectedFile.getName().equals(actualFile.getName())) {
-        expectedFileContentStr = fileIndexMd5sumReplacementPattern.matcher(expectedFileContentStr).replaceAll("");
-        actualFileStr = fileIndexMd5sumReplacementPattern.matcher(actualFileStr).replaceAll("");
-        expectedSha1 = DigestUtils.sha1Hex(expectedFileContentStr);
-        actualSha1 = DigestUtils.sha1Hex(actualFileStr);
-      } else {
-
         logger.debug("sha1 sum of [" + actualFile.getAbsolutePath() + "] is [" + actualSha1
           + "], and does not match the expected sha1 sum of [" + expectedFile.getAbsolutePath() + "], which is ["
           + expectedSha1 + "]");
-      }
     }
-
     assert expectedSha1.equals(actualSha1) : "Expected the content of [" + actualFile.getAbsolutePath()
       + "] to match the content of [" + expectedFile.getAbsolutePath() + "]";
   }

--- a/dbptk-core/src/test/java/com/databasepreservation/siarddk/SIARDDKTestUtil.java
+++ b/dbptk-core/src/test/java/com/databasepreservation/siarddk/SIARDDKTestUtil.java
@@ -6,6 +6,7 @@ import java.nio.file.Path;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
+import org.apache.commons.codec.Charsets;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
 import org.testng.FileAssert;
@@ -69,8 +70,13 @@ public class SIARDDKTestUtil {
     byte[] expectedFileContent = FileUtils.readFileToByteArray(expectedFile);
     byte[] actualFileContent = FileUtils.readFileToByteArray(actualFile);
 
-    String expectedSha1 = DigestUtils.sha1Hex(expectedFileContent);
-    String actualSha1 = DigestUtils.sha1Hex(actualFileContent);
+    String expectedFileContentStr = new String(expectedFileContent, Charsets.UTF_8);
+    String actualFileStr = new String(actualFileContent, Charsets.UTF_8);
+
+    expectedFileContentStr = expectedFileContentStr.replace("\n", System.lineSeparator());
+
+    String expectedSha1 = DigestUtils.sha1Hex(expectedFileContentStr);
+    String actualSha1 = DigestUtils.sha1Hex(actualFileStr);
 
     if (!expectedSha1.equals(actualSha1)) {
       logger.debug("sha1 sum of [" + actualFile.getAbsolutePath() + "] is [" + actualSha1

--- a/dbptk-core/src/test/java/com/databasepreservation/siarddk/TestSIARDDKImportModule.java
+++ b/dbptk-core/src/test/java/com/databasepreservation/siarddk/TestSIARDDKImportModule.java
@@ -1,5 +1,6 @@
 package com.databasepreservation.siarddk;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
@@ -24,14 +25,14 @@ public class TestSIARDDKImportModule {
     // We'll then compare this folder to a folder representing the expected
     // result.
 
-    Path splittedArchiveFld = FileSystems.getDefault().getPath(
-      this.getClass().getClassLoader().getResource("siarddk/AVID.SA.18001.1").getPath());
+    Path splittedArchiveFld = new File(
+      this.getClass().getClassLoader().getResource("siarddk/AVID.SA.18001.1").getFile()).toPath();
 
     Path generatedArchiveFullPath = FileSystems.getDefault().getPath(System.getProperty("java.io.tmpdir"),
       ARCHIVE_FLD_NAME_SPLIT_TEST);
 
-    Path expectedConsolidatedArchivePath = FileSystems.getDefault().getPath(
-      this.getClass().getClassLoader().getResource("siarddk/AVID.TST.4000.1").getPath());
+    Path expectedConsolidatedArchivePath = new File(
+      this.getClass().getClassLoader().getResource("siarddk/AVID.TST.4000.1").getFile()).toPath();
 
     SIARDDKTestUtil.assertArchiveFoldersEqualAfterExportImport(splittedArchiveFld, expectedConsolidatedArchivePath,
       generatedArchiveFullPath);
@@ -54,14 +55,14 @@ public class TestSIARDDKImportModule {
 
     // AVID.HEX.1000.1 becomes AVID.HEX.2000.1
 
-    Path hexArchiveFld = FileSystems.getDefault().getPath(
-      this.getClass().getClassLoader().getResource("siarddk/AVID.HEX.1000.1").getPath());
+    Path hexArchiveFld = new File(this.getClass().getClassLoader().getResource("siarddk/AVID.HEX.1000.1").getFile())
+      .toPath();
 
     Path generatedArchiveFullPath = FileSystems.getDefault().getPath(System.getProperty("java.io.tmpdir"),
       ARCHIVE_FLD_NAME_HEX_TEST);
 
-    Path expectedConsolidatedArchivePath = FileSystems.getDefault().getPath(
-      this.getClass().getClassLoader().getResource("siarddk/AVID.HEX.2000.1").getPath());
+    Path expectedConsolidatedArchivePath = new File(
+      this.getClass().getClassLoader().getResource("siarddk/AVID.HEX.2000.1").getFile()).toPath();
 
     SIARDDKTestUtil.assertArchiveFoldersEqualAfterExportImport(hexArchiveFld, expectedConsolidatedArchivePath,
       generatedArchiveFullPath);

--- a/dbptk-core/src/test/resources/siarddk/AVID.HEX.2000.1/Indices/fileIndex.xml
+++ b/dbptk-core/src/test/resources/siarddk/AVID.HEX.2000.1/Indices/fileIndex.xml
@@ -1,29 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <fileIndex xmlns="http://www.sa.dk/xmlns/diark/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sa.dk/xmlns/diark/1.0 ../Schemas/standard/fileIndex.xsd">
     <f>
-        <foN>AVID.HEX.2000.1\Tables\table1</foN>
-        <fiN>table1.xml</fiN>
-        <md5>8C7AFF921DA82B4B801BC1F899CB3B7A</md5>
-    </f>
-    <f>
-        <foN>AVID.HEX.2000.1\Schemas\standard</foN>
-        <fiN>archiveIndex.xsd</fiN>
-        <md5>173A55066BF25975EB2D4E3770A65EA5</md5>
-    </f>
-    <f>
-        <foN>AVID.HEX.2000.1\Tables\table1</foN>
-        <fiN>table1.xsd</fiN>
-        <md5>22BA074D9AD942C913812731A32395E6</md5>
-    </f>
-    <f>
         <foN>AVID.HEX.2000.1\Indices</foN>
         <fiN>tableIndex.xml</fiN>
         <md5>0BFD6992E602AEB1A04AF847D26107A4</md5>
-    </f>
-    <f>
-        <foN>AVID.HEX.2000.1\Schemas\standard</foN>
-        <fiN>fileIndex.xsd</fiN>
-        <md5>C868C0C9D4E5F89A763E88BC081BB064</md5>
     </f>
     <f>
         <foN>AVID.HEX.2000.1\Schemas\standard</foN>
@@ -32,12 +12,32 @@
     </f>
     <f>
         <foN>AVID.HEX.2000.1\Schemas\standard</foN>
+        <fiN>archiveIndex.xsd</fiN>
+        <md5>173A55066BF25975EB2D4E3770A65EA5</md5>
+    </f>
+    <f>
+        <foN>AVID.HEX.2000.1\Schemas\standard</foN>
         <fiN>contextDocumentationIndex.xsd</fiN>
         <md5>198D67E3D8A8515B4A0AEE5320E7926C</md5>
     </f>
     <f>
         <foN>AVID.HEX.2000.1\Schemas\standard</foN>
+        <fiN>fileIndex.xsd</fiN>
+        <md5>C868C0C9D4E5F89A763E88BC081BB064</md5>
+    </f>
+    <f>
+        <foN>AVID.HEX.2000.1\Schemas\standard</foN>
         <fiN>tableIndex.xsd</fiN>
         <md5>9661F1CDC7B36EC85DB088A42D2E125F</md5>
+    </f>
+    <f>
+        <foN>AVID.HEX.2000.1\Tables\table1</foN>
+        <fiN>table1.xml</fiN>
+        <md5>8C7AFF921DA82B4B801BC1F899CB3B7A</md5>
+    </f>
+    <f>
+        <foN>AVID.HEX.2000.1\Tables\table1</foN>
+        <fiN>table1.xsd</fiN>
+        <md5>22BA074D9AD942C913812731A32395E6</md5>
     </f>
 </fileIndex>

--- a/dbptk-core/src/test/resources/siarddk/AVID.TST.4000.1/Indices/fileIndex.xml
+++ b/dbptk-core/src/test/resources/siarddk/AVID.TST.4000.1/Indices/fileIndex.xml
@@ -1,49 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <fileIndex xmlns="http://www.sa.dk/xmlns/diark/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sa.dk/xmlns/diark/1.0 ../Schemas/standard/fileIndex.xsd">
     <f>
-        <foN>AVID.TST.4000.1\Tables\table1</foN>
-        <fiN>table1.xml</fiN>
-        <md5>A80504BBDB4B486AFCF96D705FDB2A0E</md5>
-    </f>
-    <f>
-        <foN>AVID.TST.4000.1\Tables\table2</foN>
-        <fiN>table2.xml</fiN>
-        <md5>2B69F1170B05D0DF714D633386E85625</md5>
-    </f>
-    <f>
-        <foN>AVID.TST.4000.1\Tables\table3</foN>
-        <fiN>table3.xml</fiN>
-        <md5>49A309B3E6A22BBB08B35F93A6DC2E7B</md5>
-    </f>
-    <f>
-        <foN>AVID.TST.4000.1\Schemas\standard</foN>
-        <fiN>archiveIndex.xsd</fiN>
-        <md5>173A55066BF25975EB2D4E3770A65EA5</md5>
-    </f>
-    <f>
-        <foN>AVID.TST.4000.1\Tables\table1</foN>
-        <fiN>table1.xsd</fiN>
-        <md5>F074ECC2F697BAC63D4D0CCED8A5338B</md5>
-    </f>
-    <f>
-        <foN>AVID.TST.4000.1\Tables\table2</foN>
-        <fiN>table2.xsd</fiN>
-        <md5>0C6300F4D58DDC1B7B8F692CC8F80407</md5>
-    </f>
-    <f>
-        <foN>AVID.TST.4000.1\Tables\table3</foN>
-        <fiN>table3.xsd</fiN>
-        <md5>4C86CF4C4F89C11E9F996C4C0E957EFB</md5>
-    </f>
-    <f>
         <foN>AVID.TST.4000.1\Indices</foN>
         <fiN>tableIndex.xml</fiN>
         <md5>32BB715E4570389DF72C630EC7C1F6D5</md5>
-    </f>
-    <f>
-        <foN>AVID.TST.4000.1\Schemas\standard</foN>
-        <fiN>fileIndex.xsd</fiN>
-        <md5>C868C0C9D4E5F89A763E88BC081BB064</md5>
     </f>
     <f>
         <foN>AVID.TST.4000.1\Schemas\standard</foN>
@@ -52,12 +12,52 @@
     </f>
     <f>
         <foN>AVID.TST.4000.1\Schemas\standard</foN>
+        <fiN>archiveIndex.xsd</fiN>
+        <md5>173A55066BF25975EB2D4E3770A65EA5</md5>
+    </f>
+    <f>
+        <foN>AVID.TST.4000.1\Schemas\standard</foN>
         <fiN>contextDocumentationIndex.xsd</fiN>
         <md5>198D67E3D8A8515B4A0AEE5320E7926C</md5>
     </f>
     <f>
         <foN>AVID.TST.4000.1\Schemas\standard</foN>
+        <fiN>fileIndex.xsd</fiN>
+        <md5>C868C0C9D4E5F89A763E88BC081BB064</md5>
+    </f>
+    <f>
+        <foN>AVID.TST.4000.1\Schemas\standard</foN>
         <fiN>tableIndex.xsd</fiN>
         <md5>9661F1CDC7B36EC85DB088A42D2E125F</md5>
+    </f>
+    <f>
+        <foN>AVID.TST.4000.1\Tables\table1</foN>
+        <fiN>table1.xml</fiN>
+        <md5>A80504BBDB4B486AFCF96D705FDB2A0E</md5>
+    </f>
+    <f>
+        <foN>AVID.TST.4000.1\Tables\table1</foN>
+        <fiN>table1.xsd</fiN>
+        <md5>F074ECC2F697BAC63D4D0CCED8A5338B</md5>
+    </f>
+    <f>
+        <foN>AVID.TST.4000.1\Tables\table2</foN>
+        <fiN>table2.xml</fiN>
+        <md5>2B69F1170B05D0DF714D633386E85625</md5>
+    </f>
+    <f>
+        <foN>AVID.TST.4000.1\Tables\table2</foN>
+        <fiN>table2.xsd</fiN>
+        <md5>0C6300F4D58DDC1B7B8F692CC8F80407</md5>
+    </f>
+    <f>
+        <foN>AVID.TST.4000.1\Tables\table3</foN>
+        <fiN>table3.xml</fiN>
+        <md5>49A309B3E6A22BBB08B35F93A6DC2E7B</md5>
+    </f>
+    <f>
+        <foN>AVID.TST.4000.1\Tables\table3</foN>
+        <fiN>table3.xsd</fiN>
+        <md5>4C86CF4C4F89C11E9F996C4C0E957EFB</md5>
     </f>
 </fileIndex>


### PR DESCRIPTION
Hej Andreas,

Jeg tænkte - efter path-problemerne vi opdagede i fredags på linux - at jeg også hellere lige måtte teste at testene i grupperne 'siarddk' og 'siarddk-roundtrip' også kunne afvikles med succes på windows. Det gav anledning til lidt justeringer, som er samlet i denne branch. Jeg har også gentestet disse test på linux og der kan de stadigvæk køres med success (på mac ligeså).

 Det er små ting, der er rettet (men det tog lidt tid at finde frem til problemerne, da da min git-klient på windows var sat op til automatisk at ændre line-endings - så det er måske lige værd at være OBS på, hvis du får problemer md5sum- eller sha1sum- beregninger der ikke arter sig for test-arkiver, som findes i vores git-repo ).

Håber ændringerne hjælper dig - nu har jeg det i hvert bedre med afleveringen;-)

mvh
Thomas 
